### PR TITLE
Fix rails 5 deprecation warning

### DIFF
--- a/lib/scout_statsd_rack/railtie.rb
+++ b/lib/scout_statsd_rack/railtie.rb
@@ -1,7 +1,7 @@
 module ScoutStatsdRack
   class Railtie < Rails::Railtie
     initializer "scout_statsd_rack.insert_middleware" do |app|
-      app.config.middleware.use "ScoutStatsdRack::Middleware"
+      app.config.middleware.use ScoutStatsdRack::Middleware
     end
   end
 end


### PR DESCRIPTION
The full warning from rails 5.0.1:

```DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "ScoutStatsdRack::Middleware" => ScoutStatsdRack::Middleware```